### PR TITLE
added more GameMode checks to entity-utilities.js

### DIFF
--- a/utilities/entity-utilities.js
+++ b/utilities/entity-utilities.js
@@ -183,4 +183,4 @@ export function isRidingEntity(player, entityType) {
  *  world.sendMessage(`${player.name} is in creative!`)
  * };
  */
-export const isCreative = (player) => player.getGameMode() == GameMode.creative
+export const isCreative = (player) => player.getGameMode() == (GameMode.creative || GameMode.Create)

--- a/utilities/entity-utilities.js
+++ b/utilities/entity-utilities.js
@@ -183,4 +183,7 @@ export function isRidingEntity(player, entityType) {
  *  world.sendMessage(`${player.name} is in creative!`)
  * };
  */
-export const isCreative = (player) => player.getGameMode() == (GameMode.creative || GameMode.Create)
+export const isCreative = (player) => player.getGameMode() == (GameMode.creative || GameMode.Creative)
+export const isSurvival = (player) => player.getGameMode() == (GameMode.survival || GameMode.Survival)
+export const isSpectator = (player) => player.getGameMode() == (GameMode.spectator || GameMode.Spectator)
+export const isAdventure = (player) => player.getGameMode() == (GameMode.adventure || GameMode.Adventure)


### PR DESCRIPTION
Fixed my isCreate typo, and added;
export const isCreative = (player) => player.getGameMode() == (GameMode.creative || GameMode.Creative);
export const isSurvival = (player) => player.getGameMode() == (GameMode.survival || GameMode.Survival);
export const isSpectator = (player) => player.getGameMode() == (GameMode.spectator|| GameMode.Spectator);
export const isAdventure= (player) => player.getGameMode() == (GameMode.adventure || GameMode.Adventure);
the || part is due to new previews making the modes Capitalised
creative => Creative
adventure => Adventure
survival => Survival
spectator => Spectator